### PR TITLE
underscore.string upgraded to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "hooker": "~0.2.3",
     "lodash": "~2.4.1",
-    "underscore.string": "~2.3.3",
+    "underscore.string": "~2.4.0",
     "colors": "~0.6.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Retire.js shows a warning that a vulnerable version of jquery is used in grunt-legacy-log dependencies. It probably isn't a problem in production but the warning is useless.

$ retire
Loading from cache: https://raw.github.com/bekk/retire.js/master/repository/jsrepository.json
Loading from cache: https://raw.github.com/bekk/retire.js/master/repository/npmrepository.json
/some/path/grunt-legacy-log/node_modules/underscore.string/test/test_underscore/vendor/jquery.js
 ↳ jquery 1.7.2 has known vulnerabilities: http://bugs.jquery.com/ticket/11290 http://research.insecurelabs.org/jquery/test/