### PR TITLE
Switch grunt-legacy-log-utils dep back to tilde version selector

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "colors": "~0.6.2",
-    "grunt-legacy-log-utils": "^0.1.1",
+    "grunt-legacy-log-utils": "~0.1.1",
     "hooker": "~0.2.3",
     "lodash": "~2.4.1",
     "underscore.string": "~2.3.3"


### PR DESCRIPTION
To maintain compatibility with node v0.8.x, as the caret selector is not available in this Node version.

Fixes https://github.com/gruntjs/grunt-legacy-log/issues/10