### PR TITLE
Revert colors back to 0.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "legacy"
   ],
   "dependencies": {
-    "colors": "0.6.2",
+    "colors": "~0.6.2",
     "grunt-legacy-log-utils": "~1.0.0",
     "hooker": "~0.2.3",
     "lodash": "~3.10.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   },
   "license": "MIT",
   "main": "index.js",
-  
   "scripts": {
     "test": "grunt test"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "legacy"
   ],
   "dependencies": {
-    "colors": "~1.1.2",
+    "colors": "~0.6.2",
     "grunt-legacy-log-utils": "~1.0.0",
     "hooker": "~0.2.3",
     "lodash": "~3.10.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "legacy"
   ],
   "dependencies": {
-    "colors": "~0.6.2",
+    "colors": "0.6.2",
     "grunt-legacy-log-utils": "~1.0.0",
     "hooker": "~0.2.3",
     "lodash": "~3.10.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "license": "MIT",
   "main": "index.js",
+  
   "scripts": {
     "test": "grunt test"
   },


### PR DESCRIPTION
It was causing colors to not show in grunt.

@shama or @vladikoff please could you review and merge.
