### PR TITLE
Update grunt to 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "underscore.string": "~3.2.3"
   },
   "devDependencies": {
-    "grunt": "^0.4.5",
+    "grunt": "^1.0.1",
     "grunt-cli": "^1.2.0",
     "grunt-contrib-jshint": "^1.0.0",
     "grunt-contrib-nodeunit": "^1.0.0",


### PR DESCRIPTION
Still show grunt 0.4.5 in https://ci.appveyor.com/project/gruntjs/grunt-legacy-log/build/1.0.22/job/l57tew94s8hrypdf