### PR TITLE
Release v3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+- v3.0.1:
+  - date: 2026-04-07
+  - changes:
+    - Update lodash to fix security warning ([#35](https://github.com/gruntjs/grunt-legacy-log/issues/35))
+    - Update to latest grunt-legacy-log-utils
 - v3.0.0:
   - date: 2020-07-27
   - changes:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-legacy-log",
   "description": "The Grunt 0.4.x logger.",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "author": "\"Cowboy\" Ben Alman (http://benalman.com/)",
   "homepage": "http://gruntjs.com/",
   "repository": {


### PR DESCRIPTION
Motivated by https://github.com/gruntjs/grunt-legacy-log/issues/35, by applying the update we released at https://github.com/gruntjs/grunt-legacy-log-utils/pull/10, and updating `lodash`.

@vladikoff Can you publish this to npm and/or add me to the package?